### PR TITLE
Pisa

### DIFF
--- a/inplaceeditform/fields.py
+++ b/inplaceeditform/fields.py
@@ -117,14 +117,25 @@ class BaseAdaptorField(object):
                                 {'config': self.config})
 
     def can_edit(self):
-        can_edit_adaptor_path = getattr(settings, 'ADAPTOR_INPLACEEDIT_EDIT', None)
-        if can_edit_adaptor_path:
-            path_module, class_adaptor = ('.'.join(can_edit_adaptor_path.split('.')[:-1]),
-                                          can_edit_adaptor_path.split('.')[-1])
-            cls_perm = getattr(import_module(path_module), class_adaptor)
-        else:
-            cls_perm = SuperUserPermEditInline
-        return cls_perm.can_edit(self)
+        '''
+        Seems to be the checking to see if the field is editable or not.
+
+        Added a try catch with a fallback to False to prevent error when the
+        template is called directly from another view (in this case our pdf
+        generator).
+        '''
+        try:
+            can_edit_adaptor_path = getattr(settings, 'ADAPTOR_INPLACEEDIT_EDIT', None)
+            if can_edit_adaptor_path:
+                path_module, class_adaptor = ('.'.join(can_edit_adaptor_path.split('.')[:-1]),
+											  can_edit_adaptor_path.split('.')[-1])
+                cls_perm = getattr(import_module(path_module), class_adaptor)
+            else:
+                cls_perm = SuperUserPermEditInline
+            return cls_perm.can_edit(self)
+        except:
+            return False
+
 
     def loads_to_post(self, request):
         return simplejson.loads(request.POST.get('value'))


### PR DESCRIPTION
Quick fix to get the error from pisa displaying the page in pdf when containing edit in place fields.

My guess is that it can't get the request.user to check the permissions from pisa displaying the page.
Anyway, as i don't need the edit in place in pdfs i just return false in case the can_edit throws an exception.
