### PR TITLE
Clarify Installation Section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,19 +35,20 @@ Requirements
 Installation
 ============
 
-Install in your base.html
--------------------------
+In your base.html
+-----------------
 
-::
+Add ::
 
     {% load inplace_edit %}
-    ...
-    <head>
-        {% inplace_toolbar %}
-    or
-        {% inplace_static %}
-    ...
-    </head>
+
+and wherever you load your static files, add either ::
+
+    {% inplace_toolbar %}
+
+or ::
+
+    {% inplace_static %}
 
 
 In your settings.py
@@ -429,4 +430,3 @@ You can get the last bleeding edge version of inplaceedit by doing a checkout
 of its git repository::
 
   git clone git://github.com/Yaco-Sistemas/django-inplaceedit.git
-


### PR DESCRIPTION
I feel like this would've gotten me to the "It works for my installation" stage a bit sooner. 

The way it is now it looks like those two lines can actually follow one another literally, which just prepends a bunch of html/js to before the opening `<html>`.
