### PR TITLE
Custom widget attributes possible now, with prefix of widget_property__

### DIFF
--- a/inplaceeditform/fields.py
+++ b/inplaceeditform/fields.py
@@ -16,6 +16,7 @@
 import json
 import numbers
 import sys
+import re
 
 from copy import deepcopy
 
@@ -117,6 +118,7 @@ class BaseAdaptorField(object):
     def get_field(self):
         field = self.get_form()[self.field_name]
         field = self._adding_size(field)
+        field = self._adding_attrs(field)
         return field
 
     def get_value_editor(self, value):
@@ -250,6 +252,19 @@ class BaseAdaptorField(object):
                 style += "%s: %s; " % (key, value)
             if style:
                 attrs['style'] = style
+        field.field.widget.attrs = attrs
+        return field
+
+    def _adding_attrs(self, field):
+        attrs = field.field.widget.attrs
+        # Loop through all key-value pairs in pass config
+        for key, value in self.config.items():
+            # Search the prefix 'widget_property__'
+            if re.search(r'widget_property__', key):
+                # Define the attribute as the part that comes
+                # after 'widget_property__'
+                attr_name = re.sub('widget_property__', '', key)
+                attrs[attr_name] = value
         field.field.widget.attrs = attrs
         return field
 

--- a/inplaceeditform/views.py
+++ b/inplaceeditform/views.py
@@ -38,7 +38,8 @@ def save_ajax(request):
         return _get_http_response({'errors': 'Params insufficient'})
     if not adaptor.can_edit():
         return _get_http_response({'errors': 'You can not edit this content'})
-    value = adaptor.loads_to_post(request)
+    # rstrip in order to remove trailing spaces or enters
+    value = adaptor.loads_to_post(request).rstrip()
     new_data = get_dict_from_obj(adaptor.obj)
     form_class = adaptor.get_form_class()
     field_name = adaptor.field_name


### PR DESCRIPTION
Related to https://github.com/Yaco-Sistemas/django-inplaceedit/issues/56

I created the possibility to add attributes to the widgets themselves.
Not 100% sure if this is the most clean implementation though...

You need to pass in your attribute with prefix 'widget_property__' in the widget.
E.g. if you have a textarea widget that you want to limit in length and rows:

{% inplace_edit "custom_field" widget_property__maxlength=140, widget_property__rows=4 %}