### PR TITLE
Allow to customize the model form directly on the model declaration.

### DIFF
--- a/inplaceeditform/fields.py
+++ b/inplaceeditform/fields.py
@@ -106,7 +106,20 @@ class BaseAdaptorField(object):
         return config
 
     def get_form_class(self):
-        return modelform_factory(self.model)
+
+        kwargs = {}
+
+        fields = getattr(self.model, 'INPLACEEDIT_FIELDS', None)
+
+        if fields:
+            kwargs['fields'] = fields
+
+        exclude = getattr(self.model, 'INPLACEEDIT_EXCLUDE', None)
+
+        if exclude:
+            kwargs['exclude'] = exclude
+
+        return modelform_factory(self.model, **kwargs)
 
     def get_form(self):
         form_class = self.get_form_class()

--- a/inplaceeditform/fields.py
+++ b/inplaceeditform/fields.py
@@ -106,8 +106,35 @@ class BaseAdaptorField(object):
         return config
 
     def get_form_class(self):
+        """ Allow to customize the modelform, or just its fields / exclude.
+
+        On your model class, define class attributes:
+
+        - ``INPLACEEDIT_FORM`` will be passed as ``form`` argument to
+          Django's ``modelform_factory()``. You can specify the form class
+          as string, like 'myproject.myapp.forms.mymodule.MyModelFormClass'.
+        - ``INPLACEEDIT_FIELDS`` will be passed as ``fields``.
+        - ``INPLACEEDIT_EXCLUDE`` will be passed as ``exclude``.
+        """
+
+        def import_obj(name):
+
+            module, objekt = name.rsplit('.', 1)
+            mod = __import__(module)
+            components = name.split('.')
+            for comp in components[1:]:
+                mod = getattr(mod, comp)
+            return mod
 
         kwargs = {}
+
+        form = getattr(self.model, 'INPLACEEDIT_FORM', None)
+
+        if form:
+            if isinstance(form, str) or isinstance(form, unicode):
+                form = import_obj(form)
+
+            kwargs['form'] = form
 
         fields = getattr(self.model, 'INPLACEEDIT_FIELDS', None)
 


### PR DESCRIPTION
Hello,

I needed this small modification to customize the `model_factory()` in `get_form_class()` of the `BaseAdapterField` in a simple manner.
This allows me to exclude model fields that are not meant to be handled via forms, or to use only a subset of `fields` in `inplaceedit`.
For example I have some JSON fields that are for internal use only, that are `blank=True`, but make `inplaceedit` crash because their `clean()` seems not clever enough (or perhaps it's me, but whatever).

A foreseable extension of this could be to add something like:

```
class MyModel(…):
    INPLACEEDIT_FORM_CLASS = 'myproject.myapp.forms.MyModelForm'
```
And make the `get_form_class()` use this class attribute if present. But I didn't need this level of customization yet.

PS: sorry, I realize this would need some documentation. I'm short of time right now, but will most probably add it in a couple of days, when I have a bunch of code in production.

Best regards,

Olivier