### PR TITLE
django 1.9 warning fixes

### DIFF
--- a/inplaceeditform/commons.py
+++ b/inplaceeditform/commons.py
@@ -43,7 +43,7 @@ def get_dict_from_obj(obj):
         if key.endswith('_id'):
             key2 = key.replace('_id', '')
             try:
-                field, model, direct, m2m = obj._meta.get_field_by_name(key2)
+                field = obj._meta.get_field(key2)
                 if isinstance(field, ForeignKey):
                     obj_dict_result[key2] = obj_dict_result[key]
                     del obj_dict_result[key]
@@ -81,10 +81,10 @@ def import_module(name, package=None):
 def get_adaptor_class(adaptor=None, obj=None, field_name=None):
     if not adaptor:
         try:
-            field = obj._meta.get_field_by_name(field_name)[0]
+            field = obj._meta.get_field(field_name)
         except FieldDoesNotExist:
             if has_transmeta:
-                field = obj._meta.get_field_by_name(transmeta.get_real_fieldname(field_name))[0]
+                field = obj._meta.get_field(transmeta.get_real_fieldname(field_name))
         if isinstance(field, models.URLField):
             adaptor = 'url'
         elif isinstance(field, models.EmailField):

--- a/inplaceeditform/urls.py
+++ b/inplaceeditform/urls.py
@@ -19,7 +19,7 @@ try:
 except ImportError:  # Django < 1.4
     from django.conf.urls.defaults import url
 
-from views import save_ajax, get_field
+from .views import save_ajax, get_field
 
 urlpatterns = (
     url(r'^save/$', save_ajax, name='inplace_save'),

--- a/inplaceeditform/urls.py
+++ b/inplaceeditform/urls.py
@@ -15,12 +15,13 @@
 # along with this programe.  If not, see <http://www.gnu.org/licenses/>.
 
 try:
-    from django.conf.urls import patterns, url
+    from django.conf.urls import url
 except ImportError:  # Django < 1.4
-    from django.conf.urls.defaults import patterns, url
+    from django.conf.urls.defaults import url
 
+from views import save_ajax, get_field
 
-urlpatterns = patterns('inplaceeditform.views',
-    url(r'^save/$', 'save_ajax', name='inplace_save'),
-    url(r'^get_field/$', 'get_field', name='inplace_get_field')
+urlpatterns = (
+    url(r'^save/$', save_ajax, name='inplace_save'),
+    url(r'^get_field/$', get_field, name='inplace_get_field')
 )


### PR DESCRIPTION
```
/Library/Python/2.7/site-packages/inplaceeditform/urls.py:24: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got save_ajax). Pass the callable instead.
  url(r'^save/$', 'save_ajax', name='inplace_save'),

/Library/Python/2.7/site-packages/inplaceeditform/urls.py:25: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got get_field). Pass the callable instead.
  url(r'^get_field/$', 'get_field', name='inplace_get_field')

/Library/Python/2.7/site-packages/inplaceeditform/urls.py:25: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^get_field/$', 'get_field', name='inplace_get_field')
```
